### PR TITLE
Skip first part of name when searching for prefixes and prepositions

### DIFF
--- a/NameParser/NameParser/Parser.cs
+++ b/NameParser/NameParser/Parser.cs
@@ -701,7 +701,8 @@ namespace NameParser
             }
 
             // join prefixes to following lastnames: ['de la Vega'], ['van Buren']
-            var prefixes = pieces.Where(IsPrefix).ToArray();
+            // skip first part to avoid counting it as a prefix, e.g. "van" is either a first name or a preposition depending on its position
+            var prefixes = pieces.Skip(1).Where(IsPrefix).ToArray();
             if (prefixes.Length > 0)
             {
                 var i = pieces.IndexOf(prefixes[0]);

--- a/NameParser/NameParserTest/NameParserTests.cs
+++ b/NameParser/NameParserTest/NameParserTests.cs
@@ -317,5 +317,19 @@ namespace NameParseTest
             Assert.AreEqual("De La Rosa", quincy.Last);
             Assert.AreEqual("Sr", quincy.Suffix);
         }
+
+        [DataRow("VAN L JOHNSON", "VAN", "L", "JOHNSON")]
+        [DataRow("VAN JOHNSON", "VAN", "", "JOHNSON")]
+        [DataRow("JOHNSON, VAN L", "VAN", "L", "JOHNSON")]
+        [TestMethod]
+        // https://github.com/aeshirey/NameParserSharp/issues/15
+        public void Prefix_AsFirstName(string full, string first, string middle, string last)
+        {
+            var sut = new HumanName(full);
+
+            Assert.AreEqual(first, sut.First);
+            Assert.AreEqual(middle, sut.Middle);
+            Assert.AreEqual(last, sut.Last);
+        }
     }
 }


### PR DESCRIPTION
Hi, I've been using this library and want to help out with an issue.

This is a fix for issue #15 .

Since name prefixes and prepositional particles (e.g. "van", "von", "de", etc.) precede the surname, these name parts will appear after the first part of the name; the change I made will skip the first part of the name when searching for prefixes.